### PR TITLE
Support for package.source

### DIFF
--- a/rules_poetry/defs.bzl
+++ b/rules_poetry/defs.bzl
@@ -135,6 +135,9 @@ def _download(ctx, requirements):
     args.add(destination.path)
     args.add("-r")
     args.add(requirements)
+    if ctx.attr.source_url != "":
+        args.add("-i")
+        args.add(ctx.attr.source_url)
 
     ctx.actions.run(
         executable = executable,
@@ -179,6 +182,7 @@ download_wheel = rule(
         "version": attr.string(mandatory = True),
         "hashes": attr.string_list(mandatory = True, allow_empty = False),
         "marker": attr.string(mandatory = True),
+        "source_url": attr.string(mandatory = True)
     },
     toolchains = ["@bazel_tools//tools/python:toolchain_type"],
 )

--- a/rules_poetry/poetry.bzl
+++ b/rules_poetry/poetry.bzl
@@ -83,7 +83,7 @@ def _impl(repository_ctx):
         if name.lower() in excludes:
             continue
 
-        if "source" in package:
+        if "source" in package and package["source"]["type"] != "legacy":
             # TODO: figure out how to deal with git and directory refs
             print("Skipping " + name)
             continue
@@ -94,6 +94,7 @@ def _impl(repository_ctx):
             version = package["version"],
             hashes = hashes[name],
             marker = package.get("marker", None),
+            source_url = package.get("source", {}).get("url", None),
             dependencies = [
                 _clean_name(name)
                 for name in package.get("dependencies", {}).keys()
@@ -123,6 +124,7 @@ download_wheel(
     version = "{version}",
     hashes = {hashes},
     marker = "{marker}",
+    source_url = "{source_url}",
     visibility = ["//visibility:private"],
     tags = [{download_tags}, "requires-network"],
 )
@@ -159,6 +161,7 @@ load("//:defs.bzl", "pip_install")
             version = package.version,
             hashes = package.hashes,
             marker = package.marker or "",
+            source_url = package.source_url or "",
             install_tags = ", ".join(install_tags),
             download_tags = ", ".join(download_tags),
             dependencies = [":install_%s" % _clean_name(package.name)] +


### PR DESCRIPTION
Fixes issue #4

Note that I'm not sure if checking that the source type is `legacy` is the right thing to do, that just happened to be the value in my case.