### PR TITLE
updates rules_python to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ implementation nor in capability. A feature summary is listed below:
 | Transitive | *yes* | no |
 | Isolation | *yes* | no |
 | Hash Validation | *yes* | depends |
-| Deterministic | *mostly* | sometimes |
+| Deterministic | yes | yes |
 | Crosstool | no | no |
 
 ----

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_python",
-    sha256 = "e220053c4454664c09628ffbb33f245e65f5fe92eb285fbd0bc3a26f173f99d0",
-    strip_prefix = "rules_python-5aa465d5d91f1d9d90cac10624e3d2faf2057bd5",
-    urls = ["https://github.com/bazelbuild/rules_python/archive/5aa465d5d91f1d9d90cac10624e3d2faf2057bd5.tar.gz"],
+    sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
+    strip_prefix = "rules_python-0.8.1",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz",
 )
 
 # This call should always be present.

--- a/rules_poetry/defs.bzl
+++ b/rules_poetry/defs.bzl
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# We no longer need to use this due to updates to rules_python, but we have not erased it for backward compatibility.
 def deterministic_env():
     return {
         # lifted from https://github.com/bazelbuild/rules_python/issues/154


### PR DESCRIPTION
I would like to update rules_python to 0.8.1 (the current latest version).

Build reproducibility is ensured in the latest version. The same process as the `deterministic_env` function is executed here:
https://github.com/bazelbuild/rules_python/blob/0.8.1/python/pip_install/extract_wheels/__init__.py#L24

We no longer need the `deterministic_env` function, but I didn't delete it for backward compatibility.

I prepared rules_python based on this page: https://github.com/bazelbuild/rules_python/releases